### PR TITLE
Add firefox stable

### DIFF
--- a/deb-get
+++ b/deb-get
@@ -488,6 +488,15 @@ function deb_quickemu() {
     fi
 }
 
+function deb_firefox-stable() {
+    if [ "${UPSTREAM_ID}" == "ubuntu" ]; then
+        PPA="ppa:ubuntu-mozilla-security/ppa"
+        PRETTY_NAME="Firefox Stable"
+        WEBSITE="https://www.mozilla.org/firefox/"
+        SUMMARY=" Safe and easy web browser from Mozilla "
+    fi
+}
+
 function deb_firefox-esr() {
     if [ "${UPSTREAM_ID}" == "ubuntu" ]; then
         PPA="ppa:mozillateam/ppa"


### PR DESCRIPTION
Q: Why this?
A: In Ubuntu, the official 'firefox' package is a redirect to snap version, with this addition in deb-get is possible get the native .deb version of official mozilla firefox for the system.

Checklist for commit approval:
* Software has to be published as a .deb. 
YES, .deb available in PPA source

* Software has to be published authoritatively by the upstream vendor, project or maintainer. 
YES, published by Mozilla

* Software must be actively maintained.
YES, via official PPA from mozilla team

* Only stable/production releases.
YES, is a stable version